### PR TITLE
ARQ-687 Added support for custom hostname verifiers and for disabling hostname verification.

### DIFF
--- a/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/CommandBuilder.java
+++ b/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/CommandBuilder.java
@@ -29,7 +29,7 @@ import java.util.List;
 public class CommandBuilder
 {
 
-   private String weblogicJarPath;
+   private String classPath;
    private String adminUrl;
    private String adminUserName;
    private String adminPassword;
@@ -42,10 +42,11 @@ public class CommandBuilder
    private boolean useJavaStandardTrust;
    private String trustStorePassword;
    private boolean ignoreHostNameVerification;
+   private String hostnameVerifierClass;
 
-   public CommandBuilder setWeblogicJarPath(String weblogicJarPath)
+   public CommandBuilder setClassPath(String classPath)
    {
-      this.weblogicJarPath = weblogicJarPath;
+      this.classPath = classPath;
       return this;
    }
 
@@ -121,6 +122,11 @@ public class CommandBuilder
       return this;
    }
 
+   public CommandBuilder setHostnameVerifierClass(String hostnameVerifierClass)
+   {
+      this.hostnameVerifierClass = hostnameVerifierClass;
+      return this;
+   }
    
    /**
     * Constructs the commandline to be used for launching weblogic.Deployer
@@ -136,7 +142,7 @@ public class CommandBuilder
       // This will avoid confusion over the cacerts file if used as the SSL Trust Store.
       cmd.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
       cmd.add("-classpath");
-      cmd.add(weblogicJarPath);
+      cmd.add(classPath);
       if(useDemoTrust)
       {
          cmd.add("-Dweblogic.security.TrustKeyStore=DemoTrust");
@@ -162,6 +168,10 @@ public class CommandBuilder
       if(ignoreHostNameVerification)
       {
          cmd.add("-Dweblogic.security.SSL.ignoreHostnameVerification=true");
+      }
+      if(hostnameVerifierClass != null && !hostnameVerifierClass.equals(""))
+      {
+         cmd.add("-Dweblogic.security.SSL.hostnameVerifier=" + hostnameVerifierClass);
       }
       cmd.add("weblogic.Deployer");
       cmd.add("-adminurl");
@@ -196,7 +206,7 @@ public class CommandBuilder
       // This will avoid confusion over the cacerts file if used as the SSL Trust Store.
       cmd.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
       cmd.add("-classpath");
-      cmd.add(weblogicJarPath);
+      cmd.add(classPath);
       if(useDemoTrust)
       {
          cmd.add("-Dweblogic.security.TrustKeyStore=DemoTrust");
@@ -222,6 +232,10 @@ public class CommandBuilder
       if(ignoreHostNameVerification)
       {
          cmd.add("-Dweblogic.security.SSL.ignoreHostnameVerification=true");
+      }
+      if(hostnameVerifierClass != null && !hostnameVerifierClass.equals(""))
+      {
+         cmd.add("-Dweblogic.security.SSL.hostnameVerifier=" + hostnameVerifierClass);
       }
       cmd.add("weblogic.Deployer");
       cmd.add("-adminurl");

--- a/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicConfiguration.java
+++ b/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicConfiguration.java
@@ -130,6 +130,17 @@ public class WebLogicConfiguration implements ContainerConfiguration
    
    private boolean ignoreHostNameVerification;
    
+   /**
+    * The fully qualified class name of the hostname verifier class
+    */
+   private String hostnameVerifierClass;
+   
+   /**
+    * The classpath entries that will be added to the classpath used by weblogic.Deployer.
+    * The location of the hostname verifier class can be provided via this property. 
+    */
+   private String classPath;
+   
    public void validate() throws ConfigurationException
    {
       // Verify the mandatory properties
@@ -215,6 +226,11 @@ public class WebLogicConfiguration implements ContainerConfiguration
                + File.separator + "cacerts";
          Validate.isValidFile(trustStoreLocation, "The trustStoreLocation file was resolved to " + trustStoreLocation
                + " and could not be located. Verify that the cacerts file is present in the JRE installation.");
+      }
+      if(hostnameVerifierClass != null && !hostnameVerifierClass.equals(""))
+      {
+         Validate.isNotNullOrEmpty(classPath);
+         classPath = weblogicJarPath + File.pathSeparator + classPath;
       }
       
       //Validate these derived properties
@@ -434,5 +450,25 @@ public class WebLogicConfiguration implements ContainerConfiguration
    {
       this.ignoreHostNameVerification = ignoreHostNameVerification;
    }
-   
+
+   public String getHostnameVerifierClass()
+   {
+      return hostnameVerifierClass;
+   }
+
+   public void setHostnameVerifierClass(String hostnameVerifierClass)
+   {
+      this.hostnameVerifierClass = hostnameVerifierClass;
+   }
+
+   public String getClassPath()
+   {
+      return classPath;
+   }
+
+   public void setClassPath(String classPath)
+   {
+      this.classPath = classPath;
+   }
+
 }

--- a/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicDeployerClient.java
+++ b/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicDeployerClient.java
@@ -72,7 +72,7 @@ public class WebLogicDeployerClient
    public void deploy(String deploymentName, File deploymentArchive) throws DeploymentException
    {
       CommandBuilder builder = new CommandBuilder()
-            .setWeblogicJarPath(configuration.getWeblogicJarPath())
+            .setClassPath(configuration.getClassPath())
             .setAdminUrl(configuration.getAdminUrl())
             .setAdminUserName(configuration.getAdminUserName())
             .setAdminPassword(configuration.getAdminPassword())
@@ -83,7 +83,8 @@ public class WebLogicDeployerClient
             .setUseCustomTrust(configuration.isUseCustomTrust())
             .setCustomTrustStore(configuration.getTrustStoreLocation())
             .setUseJavaStandardTrust(configuration.isUseJavaStandardTrust())
-            .setIgnoreHostNameVerification(configuration.isIgnoreHostNameVerification());
+            .setIgnoreHostNameVerification(configuration.isIgnoreHostNameVerification())
+            .setHostnameVerifierClass(configuration.getHostnameVerifierClass());
       
       logger.log(Level.INFO, "Starting weblogic.Deployer to deploy the test artifact.");
       forkWebLogicDeployer(builder.buildDeployCommand());
@@ -100,7 +101,7 @@ public class WebLogicDeployerClient
    public void undeploy(String deploymentName) throws DeploymentException
    {
       CommandBuilder builder = new CommandBuilder()
-            .setWeblogicJarPath(configuration.getWeblogicJarPath())
+            .setClassPath(configuration.getClassPath())
             .setAdminUrl(configuration.getAdminUrl())
             .setAdminUserName(configuration.getAdminUserName())
             .setAdminPassword(configuration.getAdminPassword())
@@ -110,7 +111,8 @@ public class WebLogicDeployerClient
             .setUseCustomTrust(configuration.isUseCustomTrust())
             .setCustomTrustStore(configuration.getTrustStoreLocation())
             .setUseJavaStandardTrust(configuration.isUseJavaStandardTrust())
-            .setIgnoreHostNameVerification(configuration.isIgnoreHostNameVerification());
+            .setIgnoreHostNameVerification(configuration.isIgnoreHostNameVerification())
+            .setHostnameVerifierClass(configuration.getHostnameVerifierClass());
       
       logger.log(Level.INFO, "Starting weblogic.Deployer to undeploy the test artifact.");
       forkWebLogicDeployer(builder.buildUndeployCommand());


### PR DESCRIPTION
Custom hostname verifiers are now supported via the introduction of two new properties - `hostnameVerifierClass` & `classPath`.

This is used only by weblogic.Deployer and not by the JMX client, as the connection to the MBean server does not appear to require hostname verification. All SSL arguments supported by weblogic.Deployer of WLS 10.3 is now supported by the Arquillian integration.
