### PR TITLE
ARQ-725 Improved the performance of the WLS container integration.

### DIFF
--- a/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicConfiguration.java
+++ b/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicConfiguration.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.container.spi.client.container.ContainerConfiguratio
 public class WebLogicConfiguration implements ContainerConfiguration
 {
 
-   private static final String WL_JMX_CLIENT_JAR_PATH = "server/lib/wljmxclient.jar";
    private static final String WEBLOGIC_JAR_PATH = "server/lib/weblogic.jar";
    
    /**
@@ -86,11 +85,6 @@ public class WebLogicConfiguration implements ContainerConfiguration
     * The location of weblogic.jar (optional)
     */
    private String weblogicJarPath;
-   
-   /**
-    * The location of the wljmxclient.jar (optional)
-    */
-   private String jmxLibPath;
    
    /**
     * The protocol to use, when connecting to the WebLogic Domain Runtime MBean Server. (optional)
@@ -175,11 +169,6 @@ public class WebLogicConfiguration implements ContainerConfiguration
          throw new IllegalArgumentException("Failed to parse the adminUrl property - " + adminUrl + " as a URI.",uriEx);
       }
       
-      if (jmxLibPath == null || jmxLibPath.equals(""))
-      {
-         this.jmxLibPath = this.wlsHome.endsWith(File.separator) ? wlsHome.concat(WL_JMX_CLIENT_JAR_PATH) : wlsHome
-               .concat(File.separator).concat(WL_JMX_CLIENT_JAR_PATH);
-      }
       if (weblogicJarPath == null || weblogicJarPath.equals(""))
       {
          this.weblogicJarPath = this.wlsHome.endsWith(File.separator) ? wlsHome.concat(WEBLOGIC_JAR_PATH) : wlsHome
@@ -242,8 +231,6 @@ public class WebLogicConfiguration implements ContainerConfiguration
       }
       
       //Validate these derived properties
-      Validate.isValidFile(jmxLibPath,
-            "The wljmxclient.jar could not be located. Verify the wlsHome and jmxLibPath properties in arquillian.xml");
       Validate
             .notNullOrEmpty(jmxProtocol,
                   "The jmxProtocol is empty. Verify the adminUrl, adminProtocol and jmxProtocol properties in arquillian.xml");
@@ -346,16 +333,6 @@ public class WebLogicConfiguration implements ContainerConfiguration
       this.weblogicJarPath = weblogicJarPath;
    }
 
-   public String getJmxLibPath()
-   {
-      return jmxLibPath;
-   }
-
-   public void setJmxLibPath(String jmxLibPath)
-   {
-      this.jmxLibPath = jmxLibPath;
-   }
-   
    public String getJmxProtocol()
    {
       return jmxProtocol;

--- a/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicJMXLibClassLoader.java
+++ b/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicJMXLibClassLoader.java
@@ -24,10 +24,10 @@ import java.util.logging.Logger;
 
 /**
  * A {@link ClassLoader} that is used to load classes
- * from <code>WL_HOME/server/lib/wljmxclient.jar</code>.
+ * from <code>WL_HOME/server/lib/weblogic.jar</code>.
  * 
  * Classloading is delegated to the parent first, before
- * attempting to load from the wljmxclient.jar file.
+ * attempting to load from the weblogic.jar file.
  * 
  * @author Vineet Reynolds
  *


### PR DESCRIPTION
Note - It would be preferable to verify the performance improvements arising out of this change. Observable improvement was around 40%.

Modified the codesource of the WebLogicJMXLibClassLoader. The codesource is now weblogic.jar instead of wljmxclient.jar to avoid setting up a SecurityManager which in turn reduces performance. This was the reason why having wlfullclient.jar in the system classpath improved performance. The use of wljmxclient.jar switches on a SecurityManager whose operations decrease performance when creating ShrinkWrap archives.

The JMX classloader is initalized on creation of a WebLogicJMXClient instance. Also, the connection to the JMX MBean Server is also created at object initialization. The WebLogicJMXClient is created only once, for an instance of the WebLogicContainer class. The state of the JVM modified by the WebLogicJMXClient is stashed for the duration of the method invocations on this class, and restored on completion.

The jmxLibPath property in arquillian.xml is no longer supported.
