### PR TITLE
ARQ-1172 Initial implementation of an embedded WLS 12c container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,5 +80,6 @@
         <module>wls-remote-12.1</module>
         <module>wls-managed-10.3</module>
         <module>wls-managed-12.1</module>
+        <module>wls-embedded-12.1</module>
     </modules>
 </project>

--- a/wls-embedded-12.1/pom.xml
+++ b/wls-embedded-12.1/pom.xml
@@ -1,0 +1,120 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.arquillian.container</groupId>
+        <artifactId>arquillian-parent-wls</artifactId>
+        <version>1.0.0.Final-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>arquillian-wls-embedded-12.1</artifactId>
+    <name>Arquillian Container WebLogic Embedded 12.1</name>
+    <properties>
+        <version.javaee-6_api>6.0</version.javaee-6_api>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-wls-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        
+        <!-- Enrichers -->
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-resource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-ejb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-initialcontext</artifactId>
+        </dependency>
+        
+        <!-- testing -->
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <!-- Java EE 6 standards support -->
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>${version.javaee-6_api}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>integration</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <!-- 80M is the default size of the permanent generation. Insufficient for embedded WLS 12c -->
+                            <argLine>-XX:MaxPermSize=128M</argLine>
+                            <!-- Disable assertions otherwise an assertionerror involving the WLS management runtime is thrown -->
+                            <enableAssertions>false</enableAssertions>
+                            <!-- Add the weblogic.jar to the classpath.
+                             Contains the embedded EJB SPI provider implementation in it's manifest classpath -->
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${env.WL_HOME}/server/lib/weblogic.jar</additionalClasspathElement>
+                            </additionalClasspathElements>
+                            <!-- Exclude the JEE 6 APIs since they do not have method bodies -->
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExcludes>javax:javaee-api</classpathDependencyExcludes>
+                            </classpathDependencyExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/wls-embedded-12.1/src/main/java/org/jboss/arquillian/container/wls/embedded_12_1/WebLogicContainer.java
+++ b/wls-embedded-12.1/src/main/java/org/jboss/arquillian/container/wls/embedded_12_1/WebLogicContainer.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.wls.embedded_12_1;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ejb.embeddable.EJBContainer;
+import javax.naming.Context;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.context.annotation.ContainerScoped;
+import org.jboss.arquillian.container.wls.ShrinkWrapUtil;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+/**
+ * A {@link DeployableContainer} implementation that uses the {@link EJBContainer} API to control an embedded WLS 12c container.
+ * 
+ * @author Vineet Reynolds
+ */
+public class WebLogicContainer implements DeployableContainer<WebLogicEmbeddedConfiguration> {
+
+    private static final Logger logger = Logger.getLogger(WebLogicContainer.class.getName());
+    private EJBContainer ejbContainer;
+    private WebLogicEmbeddedConfiguration configuration;
+
+    @Inject
+    @ContainerScoped
+    private InstanceProducer<Context> ctx;
+
+    @Override
+    public Class<WebLogicEmbeddedConfiguration> getConfigurationClass() {
+        return WebLogicEmbeddedConfiguration.class;
+    }
+
+    @Override
+    public void setup(WebLogicEmbeddedConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void start() throws LifecycleException {
+        logger.log(Level.FINE, "Starting container - initialization system properties.");
+        if (configuration.isOutputToConsole()) {
+            System.setProperty("weblogic.server.embed.debug", "true");
+            System.setProperty("weblogic.StdoutDebugEnabled", "true");
+        }
+    }
+
+    @Override
+    public void stop() throws LifecycleException {
+        logger.log(Level.FINE, "Starting container - nothing to do here.");
+    }
+
+    @Override
+    public ProtocolDescription getDefaultProtocol() {
+        return new ProtocolDescription("Local");
+    }
+
+    @Override
+    public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
+        if (ejbContainer != null) {
+            throw new DeploymentException("The embedded container does not support multiple deployments in a single test.");
+        }
+        logger.log(Level.FINE, "Deploying archive {0}", archive);
+        // Write the deployment to disk
+        File deployment = ShrinkWrapUtil.toFile(archive);
+        String deploymentName = getDeploymentName(archive);
+
+        // Prepare embedded container configuration
+        Map<String, Object> props = new HashMap<String, Object>();
+        props.put(EJBContainer.APP_NAME, deploymentName);
+        props.put(EJBContainer.MODULES, deployment);
+
+        // Start the embedded container
+        ejbContainer = EJBContainer.createEJBContainer(props);
+        ctx.set(ejbContainer.getContext());
+        return new ProtocolMetaData();
+    }
+
+    @Override
+    public void undeploy(Archive<?> archive) throws DeploymentException {
+        logger.log(Level.FINE, "Undeploying archive {0}", archive);
+        // Stop the embedded container, since there is no undeploy API.
+        // To prevent multiple deployment in the same test class scope , we'll close and nullify on undeploy.
+        if (ejbContainer != null) {
+            ejbContainer.close();
+            ejbContainer = null;
+        }
+    }
+
+    @Override
+    public void deploy(Descriptor descriptor) throws DeploymentException {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void undeploy(Descriptor descriptor) throws DeploymentException {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    private String getDeploymentName(Archive<?> archive) {
+        String archiveFilename = archive.getName();
+        int indexOfDot = archiveFilename.indexOf(".");
+        if (indexOfDot != -1) {
+            return archiveFilename.substring(0, indexOfDot);
+        }
+        return archiveFilename;
+    }
+
+}

--- a/wls-embedded-12.1/src/main/java/org/jboss/arquillian/container/wls/embedded_12_1/WebLogicEmbeddedConfiguration.java
+++ b/wls-embedded-12.1/src/main/java/org/jboss/arquillian/container/wls/embedded_12_1/WebLogicEmbeddedConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.wls.embedded_12_1;
+
+import org.jboss.arquillian.container.spi.ConfigurationException;
+import org.jboss.arquillian.container.spi.client.container.ContainerConfiguration;
+
+public class WebLogicEmbeddedConfiguration implements ContainerConfiguration {
+
+    private boolean outputToConsole;
+
+    @Override
+    public void validate() throws ConfigurationException {
+
+    }
+
+    public boolean isOutputToConsole() {
+        return outputToConsole;
+    }
+
+    public void setOutputToConsole(boolean outputToConsole) {
+        this.outputToConsole = outputToConsole;
+    }
+
+}

--- a/wls-embedded-12.1/src/main/java/org/jboss/arquillian/container/wls/embedded_12_1/WebLogicExtension.java
+++ b/wls-embedded-12.1/src/main/java/org/jboss/arquillian/container/wls/embedded_12_1/WebLogicExtension.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.wls.embedded_12_1;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * The WebLogic 12c embedded container adapter
+ * 
+ * @author Vineet Reynolds
+ */
+public class WebLogicExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(DeployableContainer.class, WebLogicContainer.class);
+    }
+
+}

--- a/wls-embedded-12.1/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/wls-embedded-12.1/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.container.wls.embedded_12_1.WebLogicExtension

--- a/wls-embedded-12.1/src/test/java/org/jboss/arquillian/container/wls/embedded_12_1/Greeter.java
+++ b/wls-embedded-12.1/src/test/java/org/jboss/arquillian/container/wls/embedded_12_1/Greeter.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @author <a href="http://community.jboss.org/people/LightGuard">Jason Porter</a>
+ */
+package org.jboss.arquillian.container.wls.embedded_12_1;
+
+import javax.ejb.Stateless;
+
+/**
+ * Basic SLSB for injection.
+ *
+ * @author <a href="http://community.jboss.org/people/aslak">Aslak Knutsen</a>
+ * @author <a href="http://community.jboss.org/people/LightGuard">Jason Porter</a>
+ */
+@Stateless
+public class Greeter
+{
+
+   /* (non-Javadoc)
+    * @see org.jboss.arquillian.container.wls.remote_103x.Greeter#greet()
+    */
+   public String greet()
+   {
+      return "Hello";
+   }
+}

--- a/wls-embedded-12.1/src/test/java/org/jboss/arquillian/container/wls/embedded_12_1/WebLogicDeployJarTest.java
+++ b/wls-embedded-12.1/src/test/java/org/jboss/arquillian/container/wls/embedded_12_1/WebLogicDeployJarTest.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * @author <a href="http://community.jboss.org/people/LightGuard">Jason Porter</a>
+ */
+package org.jboss.arquillian.container.wls.embedded_12_1;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.logging.Logger;
+
+import javax.ejb.EJB;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verifies Arquillian can deploy a JAR and run in-container tests.
+ * 
+ * @author Vineet Reynolds
+ */
+@RunWith(Arquillian.class)
+public class WebLogicDeployJarTest {
+    /**
+     * Logger
+     */
+    private static final Logger log = Logger.getLogger(WebLogicDeployJarTest.class.getName());
+
+    @EJB
+    private Greeter greeter;
+
+    /**
+     * Deployment for the test
+     * 
+     * @return
+     */
+    @Deployment
+    public static Archive<?> getTestArchive() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test.jar").addClasses(Greeter.class);
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    @Test
+    public void shouldBeAbleToDeployEnterpriseArchive() throws Exception {
+        assertThat(greeter, notNullValue());
+        assertThat(greeter.greet(), equalTo("Hello"));
+    }
+}

--- a/wls-embedded-12.1/src/test/resources/arquillian.xml
+++ b/wls-embedded-12.1/src/test/resources/arquillian.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="wls-12c-embedded" default="true">
+        <configuration>
+            <property name="outputToConsole">true</property>
+        </configuration>
+    </container>
+
+</arquillian>


### PR DESCRIPTION
An Arquillian container adapter that uses the embeddable EJB container SPI to run tests in an embedded WLS12 container.

Supports only EJB injection for now. The embeddable EJB container SPI implementation is expected to be provided by the end-user to the Surefire classpath. A sample Surefire configuration is in the project POM. Other configuration values required for running the embedded container are also provided.
