### PR TITLE
allow deploy exploded archives (restricted to FullJMXRemoteContainer)

### DIFF
--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommonWebLogicConfiguration.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommonWebLogicConfiguration.java
@@ -83,6 +83,8 @@ public class CommonWebLogicConfiguration implements ContainerConfiguration
    
    private boolean useURandom;
    
+   private boolean deployExplodedArchive;
+
    public void validate() throws ConfigurationException
    {
       // Verify the mandatory properties
@@ -515,4 +517,14 @@ public class CommonWebLogicConfiguration implements ContainerConfiguration
       this.useURandom = useURandom;
    }
 
+   public boolean isDeployExplodedArchive() {
+      return deployExplodedArchive;
+   }
+
+    /**
+     * @param deployExplodedArchive Specifies whether to deploy explode WAR before deploying, or not (default = false).
+     */
+   public void setDeployExplodedArchive(boolean deployExplodedArchive) {
+       this.deployExplodedArchive = deployExplodedArchive;
+   }
 }

--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/RemoteContainer.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/RemoteContainer.java
@@ -66,7 +66,7 @@ public class RemoteContainer {
      */
     public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
         String deploymentName = getDeploymentName(archive);
-        File deploymentArchive = ShrinkWrapUtil.toFile(archive);
+        File deploymentArchive = ShrinkWrapUtil.toFile(archive, configuration.isDeployExplodedArchive());
 
         deployerClient.deploy(deploymentName, deploymentArchive);
         return jmxClient.verifyDeployment(deploymentName);

--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/ShrinkWrapUtil.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/ShrinkWrapUtil.java
@@ -17,9 +17,15 @@
  */
 package org.jboss.arquillian.container.wls;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URL;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
@@ -106,22 +112,93 @@ public final class ShrinkWrapUtil
     */
    public static File toFile(final Archive<?> archive)
    {
-      // create a random named temp file, then delete and use it as a directory
-      try
-      {
-         File root = File.createTempFile("arquillian", archive.getName());
-         root.delete();
-         root.mkdirs();
-         
-         File deployment = new File(root, archive.getName());
-         deployment.deleteOnExit();
-         archive.as(ZipExporter.class).exportTo(deployment, true);
-         return deployment;
-      }
-      catch (Exception e) 
-      {
-         throw new RuntimeException("Could not export deployment to temp", e);
-      }
+      return toFile(archive, false);
    }
-   
+
+   /**
+    * Creates a tmp folder and exports the file. Returns the URL for that file location.
+    *
+    * @param archive Archive to export
+    * @param exploded Specifies, whether to explode the archive after creation
+    * @return
+    */
+   public static File toFile(final Archive<?> archive, final boolean exploded)
+   {
+       // create a random named temp file, then delete and use it as a directory
+       try
+       {
+           File root = File.createTempFile("arquillian", archive.getName());
+           root.delete();
+           root.mkdirs();
+
+           File deployment = new File(root, archive.getName());
+           deployment.deleteOnExit();
+           archive.as(ZipExporter.class).exportTo(deployment, true);
+           return exploded ? Unzipper.unzip(deployment, new File(new File(root, "exploded"), archive.getName()))
+                           : deployment;
+       }
+       catch (Exception e)
+       {
+           throw new RuntimeException("Could not export deployment to temp", e);
+       }
+   }
+
+    /**
+     * Simple unzip implementation used for extracting contents of deployment archive.
+     */
+   private static class Unzipper
+   {
+      private static final int BUFFER = 2048;
+
+      private static File unzip(final File archive, final File outputDir)
+      {
+         if (!outputDir.exists())
+         {
+            outputDir.mkdirs();
+         }
+
+         try {
+            BufferedOutputStream dest = null;
+            BufferedInputStream is = null;
+            ZipEntry entry;
+            ZipFile zipfile = new ZipFile(archive);
+            Enumeration e = zipfile.entries();
+            while(e.hasMoreElements())
+            {
+               entry = (ZipEntry) e.nextElement();
+
+               is = new BufferedInputStream(zipfile.getInputStream(entry));
+               int count;
+               byte data[] = new byte[BUFFER];
+
+               File outputFile = new File(outputDir, entry.getName());
+               if (entry.isDirectory())
+               {
+                  if (!outputFile.exists()) { outputFile.mkdirs(); }
+               } else
+               {
+                  ensureFileExists(outputFile);
+                  FileOutputStream fos = new FileOutputStream(outputFile);
+                  dest = new BufferedOutputStream(fos, BUFFER);
+                  while ((count = is.read(data, 0, BUFFER)) != -1)
+                  {
+                     dest.write(data, 0, count);
+                  }
+                  dest.flush();
+                  dest.close();
+               }
+               is.close();
+            }
+         } catch(Exception e) {
+            e.printStackTrace();
+         }
+         return outputDir;
+      }
+
+       private static void ensureFileExists(final File file) throws IOException
+       {
+          if (!file.getParentFile().exists()) { file.getParentFile().mkdirs(); }
+          if (!file.exists()) { file.createNewFile(); }
+       }
+   }
 }

--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/ShrinkWrapUtil.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/ShrinkWrapUtil.java
@@ -17,17 +17,12 @@
  */
 package org.jboss.arquillian.container.wls;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 
@@ -124,81 +119,28 @@ public final class ShrinkWrapUtil
     */
    public static File toFile(final Archive<?> archive, final boolean exploded)
    {
-       // create a random named temp file, then delete and use it as a directory
-       try
-       {
-           File root = File.createTempFile("arquillian", archive.getName());
-           root.delete();
-           root.mkdirs();
-
-           File deployment = new File(root, archive.getName());
-           deployment.deleteOnExit();
-           archive.as(ZipExporter.class).exportTo(deployment, true);
-           return exploded ? Unzipper.unzip(deployment, new File(new File(root, "exploded"), archive.getName()))
-                           : deployment;
-       }
-       catch (Exception e)
-       {
-           throw new RuntimeException("Could not export deployment to temp", e);
-       }
-   }
-
-    /**
-     * Simple unzip implementation used for extracting contents of deployment archive.
-     */
-   private static class Unzipper
-   {
-      private static final int BUFFER = 2048;
-
-      private static File unzip(final File archive, final File outputDir)
+      // create a random named temp file, then delete and use it as a directory
+      try
       {
-         if (!outputDir.exists())
+         File root = File.createTempFile("arquillian", archive.getName());
+         root.delete();
+         root.mkdirs();
+
+         File deployment = new File(root, archive.getName());
+         deployment.deleteOnExit();
+
+         if (exploded)
          {
-            outputDir.mkdirs();
+            return archive.as(ExplodedExporter.class).exportExploded(root, archive.getName());
+         } else
+         {
+            archive.as(ZipExporter.class).exportTo(deployment, true);
+            return deployment;
          }
-
-         try {
-            BufferedOutputStream dest = null;
-            BufferedInputStream is = null;
-            ZipEntry entry;
-            ZipFile zipfile = new ZipFile(archive);
-            Enumeration e = zipfile.entries();
-            while(e.hasMoreElements())
-            {
-               entry = (ZipEntry) e.nextElement();
-
-               is = new BufferedInputStream(zipfile.getInputStream(entry));
-               int count;
-               byte data[] = new byte[BUFFER];
-
-               File outputFile = new File(outputDir, entry.getName());
-               if (entry.isDirectory())
-               {
-                  if (!outputFile.exists()) { outputFile.mkdirs(); }
-               } else
-               {
-                  ensureFileExists(outputFile);
-                  FileOutputStream fos = new FileOutputStream(outputFile);
-                  dest = new BufferedOutputStream(fos, BUFFER);
-                  while ((count = is.read(data, 0, BUFFER)) != -1)
-                  {
-                     dest.write(data, 0, count);
-                  }
-                  dest.flush();
-                  dest.close();
-               }
-               is.close();
-            }
-         } catch(Exception e) {
-            e.printStackTrace();
-         }
-         return outputDir;
       }
-
-       private static void ensureFileExists(final File file) throws IOException
-       {
-          if (!file.getParentFile().exists()) { file.getParentFile().mkdirs(); }
-          if (!file.exists()) { file.createNewFile(); }
-       }
+      catch (Exception e)
+      {
+         throw new RuntimeException("Could not export deployment to temp", e);
+      }
    }
 }

--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/jmx/FullJMXRemoteContainer.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/jmx/FullJMXRemoteContainer.java
@@ -24,6 +24,8 @@ import org.jboss.arquillian.container.wls.ShrinkWrapUtil;
 import org.jboss.arquillian.container.wls.WebLogicJMXClient;
 import org.jboss.shrinkwrap.api.Archive;
 
+import java.io.File;
+
 /**
  * A utility class for performing operations relevant to a remote WebLogic container used by Arquillian.
  * <p>
@@ -59,7 +61,7 @@ public class FullJMXRemoteContainer {
      * @throws org.jboss.arquillian.container.spi.client.container.DeploymentException 
      */
     public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
-        return jmxClient.deploy(getDeploymentName(archive), ShrinkWrapUtil.toFile(archive));
+        return jmxClient.deploy(getDeploymentName(archive), ShrinkWrapUtil.toFile(archive, configuration.isDeployExplodedArchive()));
     }
 
     /**


### PR DESCRIPTION
Proposing to add support for exploded deployments for WLS 12.1.2 container. You activate it by setting the following container property in arquillian.xml:

```
<property name="deployExplodedArchive">true</property>
```
The default value is false.

We need this because WebLogic (when using non-exploded WAR deployment) packs the contents of WEB-INF/classes into WEB-INF/lib/_wl_cls_gen.jar which should in ideal case not break anything, but some frameworks fail to load resources from WEB-INF/classes, for instance. It is unfortunately a testing blocker for us at the moment.

The unzip implementation is rather clumsy, but I wanted to avoid adding dependencies to your project - feel free to replace it.

The exploded WAR deployment support is limited to FullJMXRemoteContainer for the moment.

Please let me know if you wanted me to do any improvements. Thanks!