### PR TITLE
"Remote" argument support for weblogic.Deployer

### DIFF
--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommandBuilder.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommandBuilder.java
@@ -44,6 +44,7 @@ public class CommandBuilder
    private boolean ignoreHostNameVerification;
    private String hostnameVerifierClass;
    private boolean useURandom;
+   private boolean remoteMachine;
 
    public CommandBuilder setClassPath(String classPath)
    {
@@ -135,6 +136,11 @@ public class CommandBuilder
       return this;
    }
 
+   public CommandBuilder setRemoteMachine(boolean remoteMachine) {
+      this.remoteMachine = remoteMachine;
+      return this;
+   }
+
   /**
     * Constructs the commandline to be used for launching weblogic.Deployer
     * to deploy an app.
@@ -200,6 +206,9 @@ public class CommandBuilder
       cmd.add(targets);
       cmd.add("-upload");
       cmd.add("-debug");
+      if (remoteMachine) {
+         cmd.add("-remote");
+      }
       return cmd;
    }
    

--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommonWebLogicConfiguration.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommonWebLogicConfiguration.java
@@ -85,6 +85,8 @@ public class CommonWebLogicConfiguration implements ContainerConfiguration
    
    private boolean deployExplodedArchive;
 
+   protected boolean remoteMachine;
+
    public void validate() throws ConfigurationException
    {
       // Verify the mandatory properties
@@ -526,5 +528,16 @@ public class CommonWebLogicConfiguration implements ContainerConfiguration
      */
    public void setDeployExplodedArchive(boolean deployExplodedArchive) {
        this.deployExplodedArchive = deployExplodedArchive;
+   }
+
+   /**
+    * Remote machine configuration flag. Specify whether the target server is located on another machine (ie. if the
+    * target server do not share the same file system as the test server).
+    *
+    * @return {@code true} if executing test on a remote machine, {@code false} otherwise.
+    */
+   // Note: getter-only, setter must be implemented in child classes.
+   public boolean isRemoteMachine() {
+      return remoteMachine;
    }
 }

--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/WebLogicDeployerClient.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/WebLogicDeployerClient.java
@@ -85,7 +85,8 @@ public class WebLogicDeployerClient
             .setUseJavaStandardTrust(configuration.isUseJavaStandardTrust())
             .setIgnoreHostNameVerification(configuration.isIgnoreHostNameVerification())
             .setHostnameVerifierClass(configuration.getHostnameVerifierClass())
-            .setUseURandom(configuration.isUseURandom());
+            .setUseURandom(configuration.isUseURandom())
+            .setRemoteMachine(configuration.isRemoteMachine());
       
       logger.log(Level.INFO, "Starting weblogic.Deployer to deploy the test artifact.");
       forkWebLogicDeployer(builder.buildDeployCommand());

--- a/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicRemoteConfiguration.java
+++ b/wls-remote-10.3/src/main/java/org/jboss/arquillian/container/wls/remote_10_3/WebLogicRemoteConfiguration.java
@@ -12,5 +12,11 @@ import org.jboss.arquillian.container.wls.CommonWebLogicConfiguration;
  */
 public class WebLogicRemoteConfiguration extends CommonWebLogicConfiguration
 {
-
+   /**
+    * @param remoteMachine Specify whether the target server is located on another machine (ie. if the target server
+    *                      do not share the same file system as the test server)
+    */
+   public void setRemoteMachine(boolean remoteMachine) {
+      this.remoteMachine = remoteMachine;
+   }
 }

--- a/wls-remote-12.1.2/src/main/java/org/jboss/arquillian/container/wls/remote_12_1_2/WebLogicRemoteConfiguration.java
+++ b/wls-remote-12.1.2/src/main/java/org/jboss/arquillian/container/wls/remote_12_1_2/WebLogicRemoteConfiguration.java
@@ -10,5 +10,11 @@ import org.jboss.arquillian.container.wls.CommonWebLogicConfiguration;
  * 
  */
 public class WebLogicRemoteConfiguration extends CommonWebLogicConfiguration {
-
+   /**
+    * @param remoteMachine Specify whether the target server is located on another machine (ie. if the target server
+    *                      do not share the same file system as the test server)
+    */
+   public void setRemoteMachine(boolean remoteMachine) {
+      this.remoteMachine = remoteMachine;
+   }
 }

--- a/wls-remote-12.1/src/main/java/org/jboss/arquillian/container/wls/remote_12_1/WebLogicRemoteConfiguration.java
+++ b/wls-remote-12.1/src/main/java/org/jboss/arquillian/container/wls/remote_12_1/WebLogicRemoteConfiguration.java
@@ -12,5 +12,11 @@ import org.jboss.arquillian.container.wls.CommonWebLogicConfiguration;
  */
 public class WebLogicRemoteConfiguration extends CommonWebLogicConfiguration
 {
-
+   /**
+    * @param remoteMachine Specify whether the target server is located on another machine (ie. if the target server
+    *                      do not share the same file system as the test server)
+    */
+   public void setRemoteMachine(boolean remoteMachine) {
+      this.remoteMachine = remoteMachine;
+   }
 }


### PR DESCRIPTION
Hi everyone,

I'm currently using Arquillian on a weblogic instance running on a remote machine (ie. not sharing the file system of the arquillian instance).

To do so, I had to add support for the "-remote" argument to the weblogic.Deployer command, here is the associated branch. This argument is available from at least WLS 9: http://docs.oracle.com/cd/E13222_01/wls/docs90/deployment/wldeployer.html

I also searched for a similar workaround for the full-JMX client (used in the 12.1.2 adapter), but without luck so far (there seems to be no way to upload the application file to the target instance using only JMX).

However, I was able to sucessfuly perform a deployment with the JSR-88 API (used internally by weblogic.Deployer). This API is available at least from WLS 10.3 and permits to easily monitor the deployment progress, so this could be an interesting alternative. If I manage to get a solution working smoothly, would you be interested in a pull request as well?

Thanks,
Jean