### PR TITLE
Use set admin port for compatibility to arquillian cube.

### DIFF
--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommonWebLogicConfiguration.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommonWebLogicConfiguration.java
@@ -41,7 +41,8 @@ public class CommonWebLogicConfiguration implements ContainerConfiguration {
 
     private String adminListenAddress;
 
-    private int adminListenPort;
+    private int adminListenPort = 7001;
+    private boolean adminListenPortSet = false;
 
     private String adminUserName;
 
@@ -114,7 +115,9 @@ public class CommonWebLogicConfiguration implements ContainerConfiguration {
             URI adminURI = new URI(adminUrl);
             adminProtocol = adminURI.getScheme();
             adminListenAddress = adminURI.getHost();
-            adminListenPort = adminURI.getPort();
+            if(!adminListenPortSet) {
+                adminListenPort = adminURI.getPort();
+            }
             Validate.notNullOrEmpty(adminProtocol,
                 "The adminProtocol is empty. Verify the adminUrl and adminProtocol properties in arquillian.xml");
             Validate.isInList(adminProtocol, new String[]
@@ -241,6 +244,7 @@ public class CommonWebLogicConfiguration implements ContainerConfiguration {
      *     The port of the admin server. This is optional. It can be derived from the adminUrl.
      */
     public void setAdminListenPort(int adminListenPort) {
+        this.adminListenPortSet = true;
         this.adminListenPort = adminListenPort;
     }
 

--- a/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommonWebLogicConfiguration.java
+++ b/wls-common/src/main/java/org/jboss/arquillian/container/wls/CommonWebLogicConfiguration.java
@@ -42,7 +42,7 @@ public class CommonWebLogicConfiguration implements ContainerConfiguration {
     private String adminListenAddress;
 
     private int adminListenPort = 7001;
-    private boolean adminListenPortSet = false;
+    protected boolean adminListenPortSet = false;
 
     private String adminUserName;
 

--- a/wls-remote-rest/src/main/java/org/jboss/arquillian/container/wls/remote/rest/WebLogicRemoteConfiguration.java
+++ b/wls-remote-rest/src/main/java/org/jboss/arquillian/container/wls/remote/rest/WebLogicRemoteConfiguration.java
@@ -20,6 +20,8 @@ import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.wls.CommonWebLogicConfiguration;
 import org.jboss.arquillian.container.wls.Validate;
 
+import javax.ws.rs.core.UriBuilder;
+
 /**
  * Arquillian properties for remote WebLogic 12.1.x+ containers.
  *
@@ -33,5 +35,20 @@ public class WebLogicRemoteConfiguration extends CommonWebLogicConfiguration {
         Validate.notNullOrEmpty(getAdminPassword(), "The password is empty. Verify the credentials in arquillian.xml");
         Validate.notNullOrEmpty(getTarget(),
             "The target for the deployment is empty. Verify the property in arquillian.xml");
+        if(this.adminListenPortSet) {
+            renewAdminUrl();
+        }
+    }
+    
+    @Override
+    public void setAdminListenPort(int adminListenPort) {
+        super.setAdminListenPort(adminListenPort);
+        if(null != getAdminUrl()) {
+            renewAdminUrl();
+        }
+    }
+    
+    private void renewAdminUrl() {
+        setAdminUrl(UriBuilder.fromUri(getAdminUrl()).port(getAdminListenPort()).build().toString());
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Now it is possible to use this container adapter together with arquillian-cube-openshift.

Because arquillian-cube-openshift uses openshift port forwarding. But the local port is created randomly. With this change the randomly generated local port is used.